### PR TITLE
Allow a custom suffix for versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# UNRELEASED
+
 # 2.1.1 - Wed May 30 2018 20:00:10
 
 - Added `--requireUnreleasedEntryFailMsg` to allow the specification of a custom fail message

--- a/src/bin/changelog-version.js
+++ b/src/bin/changelog-version.js
@@ -50,6 +50,8 @@ program
   .option('--dateFormat [format]', `Date mask to use from the "dateformat" library when
                                     replacing the versionTag.
                                     Default is "default".`)
+  .option('--suffix [string]', `Append this string to the version number. Usually used for release
+                                    builds and hotfixes, such as 1.0.0-r1`)
   .action(async function (action, opt) {
     await runRelease(opt)
   })

--- a/src/stampers/VersionStamper.js
+++ b/src/stampers/VersionStamper.js
@@ -14,6 +14,8 @@ export default class VersionStamper extends BaseStamper {
    * replaced with the version / time. Defaults to "[UNRELEASED]"
    * @param {string} [options.dateFormat] Date mask to use from the "dateformat" library when
    * replacing the versionTag. Default is "default".
+   * @param {string} [options.suffix] String that's tacked on to the end of the version. Useful
+   * when handling release builds for hotfixes, such as v1.0.1r1.
    * @param {string} [options.unreleasedTagFormat] Format to replace unreleasedTag with. Available tags are
    * "{version}" and "{date}". Default is '{version} - {date}'
    * @param {boolean} [options.requireUnreleasedEntry] If true, will throw an error if the unreleasedTag
@@ -31,6 +33,7 @@ export default class VersionStamper extends BaseStamper {
     super(options)
     this.packageFile = options.packageFile || 'package.json'
     this.dateFormat = options.dateFormat || 'default'
+    this.suffix = options.suffix || ''
     this.unreleasedTag = options.unreleasedTag || '[UNRELEASED]'
     this.unreleasedTagFormat = options.unreleasedTagFormat || '{version} - {date}'
     this.requireUnreleasedEntry = options.requireUnreleasedEntry || false
@@ -58,7 +61,7 @@ export default class VersionStamper extends BaseStamper {
     }
 
     const date = this._getReleaseDate()
-    const version = this._getVersion(packageFileContents)
+    const version = `${this._getVersion(packageFileContents)}${this.suffix}`
     const releaseStamp = this._getReleaseStamp(version, date)
 
     const newChangelogData = this._replaceUnreleasedTag(

--- a/test/stampers/VersionStamper.test.js
+++ b/test/stampers/VersionStamper.test.js
@@ -52,6 +52,33 @@ describe('VersionStamper class', () => {
       fsMock.restore()
     })
 
+    it('should update the changelog with a custom suffix', async () => {
+      fsMock({
+        'CHANGELOG.md': defaultChangelogContent,
+        'package.json': defaultVersionContent
+      })
+
+      const options = {
+        suffix: 'CawCaw'
+      }
+
+      const vs = new VersionStamper(options)
+
+      await vs.release()
+
+      const data = await readFileAsync(join(projectRoot, 'CHANGELOG.md'), 'utf8')
+
+      expect(data).to.equal(`
+# Changelog
+
+## 1.2.3CawCaw - Sat Jan 01 2000 00:00:00
+
+- I have a change!
+`)
+
+      fsMock.restore()
+    })
+
     it('should update the changelog with a custom change log file', async () => {
       const changelogFile = 'changes.md'
 


### PR DESCRIPTION
Adds the ability to specify a custom --suffix that gets tacked on
to the version number pulled from package.json.

This is useful when, for example, you cut a release branch and
begin QA testing on that release branch while devs continue merging
to master.

In this scenario the release branch is frozen in time while testing
proceeds. Sometimes (hah!) we need to pull a hotfix in from the
master branch. Now if we pull in the hotfix and the version gets
automatically bumped, we have two duplicate version numbers with
(potentially) very different source code. This is confusing to just
about everyone.

Providing a --sufix allows us to create a custom version which
clearly reflects the fact that this version is the result of some
special situation. In our example, I might specify a --suffix r2
or something similar, indicating that this version diverged from
the main trunk at some point.